### PR TITLE
fix dtActivation & dtExpiration logic

### DIFF
--- a/create.ps1
+++ b/create.ps1
@@ -316,7 +316,6 @@ try {
             $accountNewProperties = $account.PSObject.Copy()
             $accountNewProperties.PSObject.Properties.Remove('ExtID')
             
-            Write-Warning "$($accountNewProperties | ConvertTo-Json)"
             foreach ($accountNewProperty in $accountNewProperties.PSObject.Properties) {
                 # Define the value, handling nulls and escaping single quotes
                 $value = if (([String]::IsNullOrEmpty($accountNewProperty.Value)) -or $accountNewProperty.Value -eq 'NULL') {

--- a/disable.ps1
+++ b/disable.ps1
@@ -193,12 +193,14 @@ try {
         $actionMessage = "comparing current account to mapped properties"
 
         # Make sure new dtExpiration > current dtActivation
-        $dtExpiration = [datetime]::Parse($account.dtExpiration)
+        $dtExpiration = [datetime]::Parse($account.dtExpiration, [System.Globalization.CultureInfo]::GetCultureInfo("en-US"))
         $dtActivation = [datetime]::Parse($correlatedAccount.dtActivation, [System.Globalization.CultureInfo]::GetCultureInfo("en-US"))
-        if ($dtExpiration -le $dtActivation) {
+        
+        # Compare only the date parts to avoid time-related issues
+        if ($dtExpiration.Date -le $dtActivation.Date) {
             $dtActivation = $dtExpiration.AddDays(-1)
-            $account | Add-Member -NotePropertyName 'dtActivation' -NotePropertyValue ($dtActivation.AddDays(-1).ToString('MM/dd/yyyy HH:mm:ss'))
-            Write-Warning "Current dtActivation [$($correlatedAccount.dtActivation)] is later then new dtExpiration [$($account.dtExpiration)] changed dtActivation to [$($account.dtActivation)]"
+            $account | Add-Member -NotePropertyName 'dtActivation' -NotePropertyValue ($dtActivation.ToString('MM/dd/yyyy HH:mm:ss')) -Force
+            Write-Warning "Current dtActivation [$($correlatedAccount.dtActivation)] is later than or equal to new dtExpiration [$($account.dtExpiration)], changed dtActivation to [$($account.dtActivation)]"
             if ('dtActivation' -notin $accountPropertiesToCompare) { $accountPropertiesToCompare += 'dtActivation' }
         }
 


### PR DESCRIPTION
# Fix issue #15: Improve date handling in disable script

## Changes
This PR fixes date parsing and comparison issues in the `disable.ps1` script that could cause the dtActivation/dtExpiration validation to fail.

## Issues Fixed

### 1. Culture-specific date parsing
Added `[System.Globalization.CultureInfo]::GetCultureInfo("en-US")` to `[datetime]::Parse()` calls to ensure consistent date parsing regardless of system locale settings.

### 2. Date comparison with time component
Changed date comparison from comparing full datetime objects to comparing only the date parts using `.Date` property. This prevents issues where the same date with different times could cause unexpected behavior.

### 3. Double date subtraction bug
Fixed incorrect calculation where `dtActivation` was being set 2 days earlier instead of 1 day earlier. Changed from `$dtActivation.AddDays(-1).ToString()` to `$dtActivation.ToString()` since the date was already adjusted one day earlier on the previous line.

### 4. Force parameter
Added `-Force` parameter to `Add-Member` to prevent errors when the property already exists.

## Technical Details

**Before:**
```powershell
$dtExpiration = [datetime]::Parse($account.dtExpiration)
$dtActivation = [datetime]::Parse($correlatedAccount.dtActivation)
if ($dtExpiration -le $dtActivation) {
    $dtActivation = $dtExpiration.AddDays(-1)
    $account | Add-Member -NotePropertyName 'dtActivation' -NotePropertyValue ($dtActivation.AddDays(-1).ToString('MM/dd/yyyy HH:mm:ss'))
}
```

**After:**
```powershell
$dtExpiration = [datetime]::Parse($account.dtExpiration, [System.Globalization.CultureInfo]::GetCultureInfo("en-US"))
$dtActivation = [datetime]::Parse($correlatedAccount.dtActivation, [System.Globalization.CultureInfo]::GetCultureInfo("en-US"))
if ($dtExpiration.Date -le $dtActivation.Date) {
    $dtActivation = $dtExpiration.AddDays(-1)
    $account | Add-Member -NotePropertyName 'dtActivation' -NotePropertyValue ($dtActivation.ToString('MM/dd/yyyy HH:mm:ss')) -Force
}
```