### PR TITLE
Fix: fieldmapping update after using import

### DIFF
--- a/fieldMapping.json
+++ b/fieldMapping.json
@@ -53,7 +53,8 @@
             "MappingActions": [
                 {
                     "MapForActions": [
-                        "Create"
+                        "Create",
+                        "Update"
                     ],
                     "MappingMode": "Fixed",
                     "Value": "\"1\"",
@@ -201,7 +202,8 @@
             "MappingActions": [
                 {
                     "MapForActions": [
-                        "Create"
+                        "Create",
+                        "Update"
                     ],
                     "MappingMode": "Fixed",
                     "Value": "\"2\"",
@@ -302,7 +304,8 @@
             "MappingActions": [
                 {
                     "MapForActions": [
-                        "Create"
+                        "Create",
+                        "Update"
                     ],
                     "MappingMode": "Fixed",
                     "Value": "\"0\"",


### PR DESCRIPTION
When using an import account, the update script will insert the user when the user does not exist in the staging table. However, the values in the field mapping are not used. In my example, the recommended value for AuditOpenings was not used and was set to 0 instead of 1.